### PR TITLE
chore: remove local replace directive for ai module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,5 +67,3 @@ require (
 	google.golang.org/grpc v1.77.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
-
-replace github.com/joakimcarlsson/ai => ../ai


### PR DESCRIPTION
This pull request removes a local `replace` directive from the `go.mod` file, which previously pointed `github.com/joakimcarlsson/ai` to a local `../ai` directory. This means the project will now use the version of the dependency as specified in the module proxy or upstream, rather than a local copy.

* Dependency management:
  * Removed the `replace` statement for `github.com/joakimcarlsson/ai`, so the module will now use the remote version instead of a local path.