### PR TITLE
Task/28 docker sandboxed code execution tool

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -3,67 +3,78 @@ package squeeze
 import (
 	"github.com/joakimcarlsson/ai/agent"
 	llm "github.com/joakimcarlsson/ai/providers"
+	"github.com/joakimcarlsson/ai/tool"
 	"github.com/joakimcarlsson/squeeze/internal/prompt"
+	"github.com/joakimcarlsson/squeeze/internal/sandbox"
 	"github.com/joakimcarlsson/squeeze/internal/tools"
 )
 
-func defaultSubAgents(llmClient llm.LLM) []agent.SubAgentConfig {
+func defaultSubAgents(llmClient llm.LLM, sbx *sandbox.Manager) []agent.SubAgentConfig {
 	return []agent.SubAgentConfig{
-		ReconAgent(llmClient),
-		WebAnalystAgent(llmClient),
-		ExploitRunnerAgent(llmClient),
+		ReconAgent(llmClient, sbx),
+		WebAnalystAgent(llmClient, sbx),
+		ExploitRunnerAgent(llmClient, sbx),
 	}
 }
 
-func ReconAgent(llmClient llm.LLM) agent.SubAgentConfig {
+func ReconAgent(llmClient llm.LLM, sbx *sandbox.Manager) agent.SubAgentConfig {
+	agentTools := []tool.BaseTool{
+		tools.NewDNSLookup(),
+		tools.NewPortScan(),
+		tools.NewTechFingerprint(),
+		tools.NewWhois(),
+		tools.NewSSLInfo(),
+		tools.NewWebSearch(),
+		tools.NewFetch(),
+	}
+	agentTools = append(agentTools, sbx.Tools()...)
+
 	return agent.SubAgentConfig{
 		Name:        "recon",
 		Description: "Reconnaissance specialist. Delegates DNS enumeration, port scanning, technology fingerprinting, WHOIS, and SSL/TLS analysis. Returns structured findings.",
 		Agent: agent.New(llmClient,
 			agent.WithSystemPrompt(prompt.ReconAgentPrompt),
-			agent.WithTools(
-				tools.NewDNSLookup(),
-				tools.NewPortScan(),
-				tools.NewTechFingerprint(),
-				tools.NewWhois(),
-				tools.NewSSLInfo(),
-				tools.NewWebSearch(),
-				tools.NewFetch(),
-			),
+			agent.WithTools(agentTools...),
 		),
 	}
 }
 
-func WebAnalystAgent(llmClient llm.LLM) agent.SubAgentConfig {
+func WebAnalystAgent(llmClient llm.LLM, sbx *sandbox.Manager) agent.SubAgentConfig {
+	agentTools := []tool.BaseTool{
+		tools.NewHTTPProbe(),
+		tools.NewFetch(),
+		tools.NewWebSearch(),
+		tools.NewCVELookup(),
+		tools.NewTechFingerprint(),
+		tools.NewJWTInspect(),
+	}
+	agentTools = append(agentTools, sbx.Tools()...)
+
 	return agent.SubAgentConfig{
 		Name:        "web_analyst",
 		Description: "Web application analysis specialist. Probes HTTP endpoints, checks for misconfigurations, looks up CVEs, inspects JWTs, and analyzes web content. Returns structured findings.",
 		Agent: agent.New(llmClient,
 			agent.WithSystemPrompt(prompt.WebAnalystAgentPrompt),
-			agent.WithTools(
-				tools.NewHTTPProbe(),
-				tools.NewFetch(),
-				tools.NewWebSearch(),
-				tools.NewCVELookup(),
-				tools.NewTechFingerprint(),
-				tools.NewJWTInspect(),
-			),
+			agent.WithTools(agentTools...),
 		),
 	}
 }
 
-func ExploitRunnerAgent(llmClient llm.LLM) agent.SubAgentConfig {
+func ExploitRunnerAgent(llmClient llm.LLM, sbx *sandbox.Manager) agent.SubAgentConfig {
+	agentTools := []tool.BaseTool{
+		tools.NewBash(),
+		tools.NewHTTPProbe(),
+		tools.NewFetch(),
+		tools.NewWebSearch(),
+	}
+	agentTools = append(agentTools, sbx.Tools()...)
+
 	return agent.SubAgentConfig{
 		Name:        "exploit_runner",
 		Description: "Exploitation specialist. Executes operator-approved exploitation steps using shell commands and HTTP tools. ONLY runs exploits that have been explicitly approved. Returns structured findings with evidence.",
 		Agent: agent.New(llmClient,
 			agent.WithSystemPrompt(prompt.ExploitRunnerAgentPrompt),
-			agent.WithTools(
-				tools.NewBash(),
-				tools.NewHTTPProbe(),
-				tools.NewFetch(),
-				tools.NewWebSearch(),
-			),
+			agent.WithTools(agentTools...),
 		),
 	}
 }

--- a/internal/prompt/exploit_runner_agent.md
+++ b/internal/prompt/exploit_runner_agent.md
@@ -52,14 +52,24 @@ Not every exploitation attempt succeeds. When a PoC fails:
 - Do not silently retry with increasingly aggressive payloads
 </principles>
 
-<sandbox>
-Use docker_write_file and docker_run_python for writing and executing multi-step exploit scripts in the isolated Docker container. The container has internet access and pre-installed packages: requests, httpx, pwntools, impacket, cryptography, pyjwt, scapy, paramiko. Use it when:
+<docker-sandbox>
+You have access to an isolated Docker container for writing and running Python scripts. The container has internet access and starts automatically on first use.
+
+Pre-installed packages: requests, httpx, aiohttp, pwntools, impacket, cryptography, pyjwt, scapy, paramiko, beautifulsoup4, lxml.
+
+Tools: docker_write_file → docker_run_python → docker_edit_file → docker_run_python (iterate)
+
+When to use:
 - Building exploit scripts that require iteration (write → run → fix → re-run)
 - Chaining multiple steps programmatically (e.g., extract a token, then use it in a follow-up request)
 - Running custom crypto, encoding, or protocol-level attacks that need library support
+- Any multi-step exploitation that would be tedious as individual curl/http_probe calls
 
-The Docker container is for Python scripts — NOT for Frida. Frida hooks run on the target device, not in Docker.
-</sandbox>
+When NOT to use:
+- Frida scripts — you do not have Frida tools, and docker_write_file cannot create device-executable scripts
+- Single HTTP requests — use http_probe or run_bash with curl instead
+- Writing notes or documentation — include those in your response text
+</docker-sandbox>
 
 <exploit-patterns>
 Common exploitation approaches by vulnerability class:

--- a/internal/prompt/exploit_runner_agent.md
+++ b/internal/prompt/exploit_runner_agent.md
@@ -52,6 +52,15 @@ Not every exploitation attempt succeeds. When a PoC fails:
 - Do not silently retry with increasingly aggressive payloads
 </principles>
 
+<sandbox>
+Use docker_write_file and docker_run_python for writing and executing multi-step exploit scripts in the isolated Docker container. The container has internet access and pre-installed packages: requests, httpx, pwntools, impacket, cryptography, pyjwt, scapy, paramiko. Use it when:
+- Building exploit scripts that require iteration (write → run → fix → re-run)
+- Chaining multiple steps programmatically (e.g., extract a token, then use it in a follow-up request)
+- Running custom crypto, encoding, or protocol-level attacks that need library support
+
+The Docker container is for Python scripts — NOT for Frida. Frida hooks run on the target device, not in Docker.
+</sandbox>
+
 <exploit-patterns>
 Common exploitation approaches by vulnerability class:
 

--- a/internal/prompt/recon_agent.md
+++ b/internal/prompt/recon_agent.md
@@ -50,6 +50,9 @@ Use whois on all domains and notable IPs:
 - For IPs: identify ASN, hosting provider, CIDR range, abuse contact
 - Cross-reference hosting providers to understand infrastructure layout
 
+### Scripted Recon
+Use docker_write_file and docker_run_python when you need to run custom recon scripts — e.g., iterating over a large subdomain list, correlating DNS results with port scan data, or parsing and processing large volumes of recon output programmatically. The Docker container has internet access and starts automatically on first use.
+
 ### Open Source Intelligence
 Use web_search to find:
 - Publicly exposed code repositories (GitHub, GitLab, Bitbucket) belonging to the target

--- a/internal/prompt/recon_agent.md
+++ b/internal/prompt/recon_agent.md
@@ -50,8 +50,8 @@ Use whois on all domains and notable IPs:
 - For IPs: identify ASN, hosting provider, CIDR range, abuse contact
 - Cross-reference hosting providers to understand infrastructure layout
 
-### Scripted Recon
-Use docker_write_file and docker_run_python when you need to run custom recon scripts — e.g., iterating over a large subdomain list, correlating DNS results with port scan data, or parsing and processing large volumes of recon output programmatically. The Docker container has internet access and starts automatically on first use.
+### Scripted Recon (Docker)
+Use docker_write_file and docker_run_python for custom recon scripts that would be impractical as individual tool calls — e.g., iterating over a large subdomain list with custom logic, correlating DNS results with port scan data programmatically, or parsing and processing large volumes of output. The Docker container has internet access, Python 3.12, and packages like requests, httpx, and beautifulsoup4. Do not use docker tools for anything related to device instrumentation — you do not have device tools.
 
 ### Open Source Intelligence
 Use web_search to find:

--- a/internal/prompt/system.md
+++ b/internal/prompt/system.md
@@ -134,6 +134,22 @@ Patterns:
 Your job as the main agent is to orchestrate, reason about findings, make strategic decisions, and communicate with the operator. Delegate the mechanical work.
 </sub-agents>
 
+<sandbox>
+You have access to an isolated Docker container for writing and executing Python scripts. The container has internet access and starts automatically on first use — no setup needed.
+
+Tools: docker_write_file → docker_run_python → iterate (docker_edit_file / docker_run_python)
+
+When to use:
+- Probing many endpoints programmatically (e.g., crawling an API, testing auth bypass across 200 routes)
+- Writing custom exploit scripts that iterate, parse responses, and adapt
+- Data processing: parsing scan results, correlating findings, generating wordlists
+- Any task where you'd naturally write a script rather than run commands one at a time
+
+Pre-installed packages: requests, httpx, aiohttp, cryptography, pyjwt, impacket, beautifulsoup4, lxml, pwntools, scapy, paramiko.
+
+Do NOT use docker_write_file or docker_run_python for Frida scripts. Frida hooks run on the target device, not in the Docker container. Use run_frida_script for Frida.
+</sandbox>
+
 <instructions>
 - Think before you act. Plan your approach for each phase, then execute systematically.
 - Use tools to verify everything. Never guess whether a vulnerability exists — prove it with evidence or move on.

--- a/internal/prompt/system.md
+++ b/internal/prompt/system.md
@@ -134,21 +134,47 @@ Patterns:
 Your job as the main agent is to orchestrate, reason about findings, make strategic decisions, and communicate with the operator. Delegate the mechanical work.
 </sub-agents>
 
-<sandbox>
-You have access to an isolated Docker container for writing and executing Python scripts. The container has internet access and starts automatically on first use — no setup needed.
+<tool-environments>
+HARD RULE: You operate across two completely separate execution environments. Never mix them.
 
-Tools: docker_write_file → docker_run_python → iterate (docker_edit_file / docker_run_python)
+## Docker Container (Python scripting)
+An isolated Docker container with Python 3.12 and internet access. Starts automatically on first use.
+Pre-installed: requests, httpx, aiohttp, cryptography, pyjwt, impacket, beautifulsoup4, lxml, pwntools, scapy, paramiko.
+
+Tools: docker_write_file, docker_edit_file, docker_run_python, docker_get_output
 
 When to use:
-- Probing many endpoints programmatically (e.g., crawling an API, testing auth bypass across 200 routes)
-- Writing custom exploit scripts that iterate, parse responses, and adapt
-- Data processing: parsing scan results, correlating findings, generating wordlists
-- Any task where you'd naturally write a script rather than run commands one at a time
+- Batch HTTP probing (crawling an API, testing auth bypass across many routes)
+- Multi-step exploit scripts that iterate on results
+- Data processing (parsing scan output, correlating findings, generating wordlists)
+- Any task where you would naturally write a Python script
 
-Pre-installed packages: requests, httpx, aiohttp, cryptography, pyjwt, impacket, beautifulsoup4, lxml, pwntools, scapy, paramiko.
+Workflow: docker_write_file → docker_run_python → read output → docker_edit_file → docker_run_python → repeat
 
-Do NOT use docker_write_file or docker_run_python for Frida scripts. Frida hooks run on the target device, not in the Docker container. Use run_frida_script for Frida.
-</sandbox>
+These tools are available to your sub-agents (recon, web_analyst, exploit_runner). Delegate scripting work to them.
+
+## Target Device (Frida instrumentation)
+The physical or emulated device running the target app. Frida hooks execute inside the app's process.
+
+Tools: run_frida_script, stop_frida_script, get_script_output, attach_app, detach_app
+
+When to use:
+- Dynamic analysis of the running app (hooking methods, intercepting API calls)
+- Runtime inspection (class enumeration, memory scanning, crypto monitoring)
+- Bypassing client-side protections (SSL pinning, root detection, certificate validation)
+
+## Routing rules
+- Writing a Python (.py) script → docker_write_file
+- Writing a Frida (.ts/.js) hook → run_frida_script (pass the script content directly)
+- Running Python code → docker_run_python
+- Running Frida hooks on the device → run_frida_script
+- Reading Python script output → docker_get_output
+- Reading Frida hook output → get_script_output
+- Writing notes, markdown, or documentation → do not use docker_write_file, just include it in your response text
+
+Never write Frida scripts (.ts/.js) into the Docker container. They cannot execute there.
+Never write Python scripts onto the target device. They cannot execute there.
+</tool-environments>
 
 <instructions>
 - Think before you act. Plan your approach for each phase, then execute systematically.

--- a/internal/prompt/web_analyst_agent.md
+++ b/internal/prompt/web_analyst_agent.md
@@ -57,8 +57,8 @@ For every identified technology and version:
 - Analyze API responses: Do they include more fields than the UI displays? Internal IDs, email addresses, roles, timestamps that shouldn't be exposed?
 - Check error handling: Do errors reveal stack traces, SQL queries, file paths, or framework versions?
 
-### Scripted Analysis
-Use docker_write_file and docker_run_python when you need to test many endpoints programmatically — e.g., fuzzing parameters across dozens of routes, scripting authentication bypass checks, or writing custom parsers for API responses. The Docker container has internet access and starts automatically on first use.
+### Scripted Analysis (Docker)
+Use docker_write_file and docker_run_python for testing many endpoints programmatically — e.g., fuzzing parameters across dozens of routes, scripting authentication bypass checks across an entire API surface, or writing custom response parsers. The Docker container has internet access, Python 3.12, and packages like requests, httpx, beautifulsoup4, and pyjwt. Do not use docker tools for anything related to device instrumentation — you do not have device tools.
 
 ### CORS, CSRF, and Cross-Origin Issues
 - Test CORS by sending requests with different Origin headers. Check if the origin is reflected, if credentials are allowed, if null origin is accepted.

--- a/internal/prompt/web_analyst_agent.md
+++ b/internal/prompt/web_analyst_agent.md
@@ -57,6 +57,9 @@ For every identified technology and version:
 - Analyze API responses: Do they include more fields than the UI displays? Internal IDs, email addresses, roles, timestamps that shouldn't be exposed?
 - Check error handling: Do errors reveal stack traces, SQL queries, file paths, or framework versions?
 
+### Scripted Analysis
+Use docker_write_file and docker_run_python when you need to test many endpoints programmatically — e.g., fuzzing parameters across dozens of routes, scripting authentication bypass checks, or writing custom parsers for API responses. The Docker container has internet access and starts automatically on first use.
+
 ### CORS, CSRF, and Cross-Origin Issues
 - Test CORS by sending requests with different Origin headers. Check if the origin is reflected, if credentials are allowed, if null origin is accepted.
 - Check for CSRF protections on state-changing endpoints: anti-CSRF tokens, SameSite cookies, custom header requirements.

--- a/internal/sandbox/docker.go
+++ b/internal/sandbox/docker.go
@@ -1,0 +1,128 @@
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	imageName      = "squeeze-sandbox:latest"
+	containerLabel = "squeeze-sandbox=true"
+)
+
+type runOpts struct {
+	Memory  string
+	CPUs    string
+	Network string
+}
+
+func defaultRunOpts() runOpts {
+	return runOpts{
+		Memory:  "512m",
+		CPUs:    "1",
+		Network: "none",
+	}
+}
+
+func dockerRun(ctx context.Context, image string, opts runOpts) (string, error) {
+	args := []string{
+		"run", "-d", "--rm",
+		"--label", containerLabel,
+		"--memory", opts.Memory,
+		"--cpus", opts.CPUs,
+		"--network", opts.Network,
+		"--pids-limit", "256",
+		image,
+		"sleep", "infinity",
+	}
+
+	out, err := dockerCmd(ctx, args...)
+	if err != nil {
+		return "", fmt.Errorf("docker run: %w", err)
+	}
+
+	return strings.TrimSpace(out), nil
+}
+
+func dockerExec(ctx context.Context, containerID string, cmd []string, timeout time.Duration) (stdout, stderr string, exitCode int, err error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := append([]string{"exec", containerID}, cmd...)
+
+	command := exec.CommandContext(ctx, "docker", args...)
+	var outBuf, errBuf bytes.Buffer
+	command.Stdout = &outBuf
+	command.Stderr = &errBuf
+
+	runErr := command.Run()
+	stdout, stderr = outBuf.String(), errBuf.String()
+	exitCode, err = handleExecResult(ctx, runErr, timeout)
+	return
+}
+
+func dockerExecWithStdin(ctx context.Context, containerID string, cmd []string, stdin string, timeout time.Duration) (stdout, stderr string, exitCode int, err error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	args := append([]string{"exec", "-i", containerID}, cmd...)
+
+	command := exec.CommandContext(ctx, "docker", args...)
+	command.Stdin = strings.NewReader(stdin)
+	var outBuf, errBuf bytes.Buffer
+	command.Stdout = &outBuf
+	command.Stderr = &errBuf
+
+	runErr := command.Run()
+	stdout, stderr = outBuf.String(), errBuf.String()
+	exitCode, err = handleExecResult(ctx, runErr, timeout)
+	return
+}
+
+func handleExecResult(ctx context.Context, runErr error, timeout time.Duration) (int, error) {
+	if runErr == nil {
+		return 0, nil
+	}
+
+	if ctx.Err() == context.DeadlineExceeded {
+		return -1, fmt.Errorf("execution timed out after %v", timeout)
+	}
+
+	if exitErr, ok := runErr.(*exec.ExitError); ok {
+		return exitErr.ExitCode(), nil
+	}
+
+	return -1, fmt.Errorf("docker exec: %w", runErr)
+}
+
+func dockerKill(ctx context.Context, containerID string) error {
+	_, err := dockerCmd(ctx, "kill", containerID)
+	return err
+}
+
+func dockerImageExists(ctx context.Context, image string) bool {
+	_, err := dockerCmd(ctx, "image", "inspect", image)
+	return err == nil
+}
+
+func dockerBuild(ctx context.Context, contextDir, tag string) error {
+	_, err := dockerCmd(ctx, "build", "-t", tag, contextDir)
+	return err
+}
+
+func dockerCmd(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "docker", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+
+	return stdout.String(), nil
+}

--- a/internal/sandbox/edit_file.go
+++ b/internal/sandbox/edit_file.go
@@ -1,0 +1,99 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/joakimcarlsson/ai/agent"
+	"github.com/joakimcarlsson/ai/tool"
+)
+
+type editFileParams struct {
+	Path   string `json:"path"    desc:"File path inside the container to edit"`
+	OldStr string `json:"old_str" desc:"Exact text to find and replace (must appear exactly once)"`
+	NewStr string `json:"new_str" desc:"Replacement text"`
+}
+
+type EditFileTool struct {
+	mgr *Manager
+}
+
+func (t *EditFileTool) Info() tool.ToolInfo {
+	return tool.NewToolInfo(
+		"docker_edit_file",
+		"Edit a file inside the Docker container using string replacement. The old_str must appear exactly once. Auto-lints .py files.",
+		editFileParams{},
+	)
+}
+
+func (t *EditFileTool) Run(ctx context.Context, params tool.ToolCall) (tool.ToolResponse, error) {
+	input, err := agent.ParseToolInput[editFileParams](params.Input)
+	if err != nil {
+		return tool.NewTextErrorResponse(fmt.Sprintf("invalid input: %v", err)), nil
+	}
+
+	if input.Path == "" {
+		return tool.NewTextErrorResponse("path is required"), nil
+	}
+	if input.OldStr == "" {
+		return tool.NewTextErrorResponse("old_str is required"), nil
+	}
+
+	if err := t.mgr.ensureRunning(ctx); err != nil {
+		return tool.NewTextErrorResponse(err.Error()), nil
+	}
+
+	containerID := t.mgr.ContainerID()
+
+	stdout, _, exitCode, err := dockerExec(
+		ctx, containerID,
+		[]string{"cat", input.Path},
+		10*time.Second,
+	)
+	if err != nil {
+		return tool.NewTextErrorResponse(fmt.Sprintf("failed to read file: %v", err)), nil
+	}
+	if exitCode != 0 {
+		return tool.NewTextErrorResponse(fmt.Sprintf("file not found: %s", input.Path)), nil
+	}
+
+	content := stdout
+	count := strings.Count(content, input.OldStr)
+	if count == 0 {
+		return tool.NewTextErrorResponse("old_str not found in file"), nil
+	}
+	if count > 1 {
+		return tool.NewTextErrorResponse(fmt.Sprintf("old_str appears %d times — it must be unique. Include more surrounding context to disambiguate", count)), nil
+	}
+
+	newContent := strings.Replace(content, input.OldStr, input.NewStr, 1)
+
+	_, stderr, exitCode, err := dockerExecWithStdin(
+		ctx, containerID,
+		[]string{"tee", input.Path},
+		newContent,
+		30*time.Second,
+	)
+	if err != nil {
+		return tool.NewTextErrorResponse(fmt.Sprintf("failed to write file: %v", err)), nil
+	}
+	if exitCode != 0 {
+		return tool.NewTextErrorResponse(fmt.Sprintf("failed to write file: %s", stderr)), nil
+	}
+
+	lintPassed, lintOutput := lintPython(ctx, containerID, input.Path)
+
+	type result struct {
+		Path       string `json:"path"`
+		LintPassed bool   `json:"lint_passed"`
+		LintOutput string `json:"lint_output,omitempty"`
+	}
+
+	return tool.NewJSONResponse(result{
+		Path:       input.Path,
+		LintPassed: lintPassed,
+		LintOutput: lintOutput,
+	}), nil
+}

--- a/internal/sandbox/edit_file.go
+++ b/internal/sandbox/edit_file.go
@@ -23,7 +23,11 @@ type EditFileTool struct {
 func (t *EditFileTool) Info() tool.ToolInfo {
 	return tool.NewToolInfo(
 		"docker_edit_file",
-		"Edit a file inside the Docker container using string replacement. The old_str must appear exactly once. Auto-lints .py files.",
+		`Edit an existing file inside the Docker container using exact string replacement.
+The old_str must appear exactly once in the file — include surrounding context to disambiguate if needed.
+Use this to iterate on Python scripts after reviewing docker_run_python output.
+Only affects files inside the Docker container — cannot edit files on the target device.
+Automatically lints .py files with py_compile.`,
 		editFileParams{},
 	)
 }

--- a/internal/sandbox/get_output.go
+++ b/internal/sandbox/get_output.go
@@ -1,0 +1,72 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/joakimcarlsson/ai/agent"
+	"github.com/joakimcarlsson/ai/tool"
+)
+
+type getOutputParams struct {
+	RunID string `json:"run_id" desc:"The run ID returned by a timed-out docker_run_python call"`
+}
+
+type GetOutputTool struct {
+	mgr *Manager
+}
+
+func (t *GetOutputTool) Info() tool.ToolInfo {
+	return tool.NewToolInfo(
+		"docker_get_output",
+		"Read stdout/stderr from a long-running Python script in the Docker container. Use the run_id from a timed-out docker_run_python call.",
+		getOutputParams{},
+	)
+}
+
+func (t *GetOutputTool) Run(ctx context.Context, params tool.ToolCall) (tool.ToolResponse, error) {
+	input, err := agent.ParseToolInput[getOutputParams](params.Input)
+	if err != nil {
+		return tool.NewTextErrorResponse(fmt.Sprintf("invalid input: %v", err)), nil
+	}
+
+	if input.RunID == "" {
+		return tool.NewTextErrorResponse("run_id is required"), nil
+	}
+
+	if err := t.mgr.ensureRunning(ctx); err != nil {
+		return tool.NewTextErrorResponse(err.Error()), nil
+	}
+
+	containerID := t.mgr.ContainerID()
+
+	stdoutFile := fmt.Sprintf("/tmp/sq_%s.out", input.RunID)
+	stderrFile := fmt.Sprintf("/tmp/sq_%s.err", input.RunID)
+	pidFile := fmt.Sprintf("/tmp/sq_%s.pid", input.RunID)
+
+	pidOut, _, _, err := dockerExec(ctx, containerID, []string{"cat", pidFile}, 5*time.Second)
+	if err != nil {
+		return tool.NewTextErrorResponse(fmt.Sprintf("run_id %q not found — no matching background execution", input.RunID)), nil
+	}
+	pid := strings.TrimSpace(pidOut)
+
+	_, _, exitCode, _ := dockerExec(ctx, containerID, []string{"kill", "-0", pid}, 5*time.Second)
+	running := exitCode == 0
+
+	stdout, _, _, _ := dockerExec(ctx, containerID, []string{"cat", stdoutFile}, 10*time.Second)
+	stderr, _, _, _ := dockerExec(ctx, containerID, []string{"cat", stderrFile}, 10*time.Second)
+
+	type result struct {
+		Stdout  string `json:"stdout"`
+		Stderr  string `json:"stderr"`
+		Running bool   `json:"running"`
+	}
+
+	return tool.NewJSONResponse(result{
+		Stdout:  stdout,
+		Stderr:  stderr,
+		Running: running,
+	}), nil
+}

--- a/internal/sandbox/get_output.go
+++ b/internal/sandbox/get_output.go
@@ -21,7 +21,10 @@ type GetOutputTool struct {
 func (t *GetOutputTool) Info() tool.ToolInfo {
 	return tool.NewToolInfo(
 		"docker_get_output",
-		"Read stdout/stderr from a long-running Python script in the Docker container. Use the run_id from a timed-out docker_run_python call.",
+		`Read stdout and stderr from a long-running Python script in the Docker container.
+Use the run_id returned by docker_run_python when a script times out — the timed-out script continues running in the background and this tool polls its output.
+Only reads output from Docker container processes.
+For Frida script output, use get_script_output instead.`,
 		getOutputParams{},
 	)
 }

--- a/internal/sandbox/image/Dockerfile
+++ b/internal/sandbox/image/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+
+RUN pip install --no-cache-dir \
+    requests \
+    httpx \
+    aiohttp \
+    cryptography \
+    pyjwt \
+    impacket \
+    beautifulsoup4 \
+    lxml \
+    pwntools \
+    scapy \
+    paramiko
+
+RUN useradd -m sandbox
+WORKDIR /workspace
+RUN chown sandbox:sandbox /workspace
+USER sandbox
+
+CMD ["sleep", "infinity"]

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -1,0 +1,156 @@
+package sandbox
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/joakimcarlsson/ai/tool"
+)
+
+//go:embed image/Dockerfile
+var dockerfileFS embed.FS
+
+type ManagerOption func(*Manager)
+
+func WithTimeout(d time.Duration) ManagerOption {
+	return func(m *Manager) { m.timeout = d }
+}
+
+type Manager struct {
+	mu          sync.Mutex
+	containerID string
+	cancel      context.CancelFunc
+
+	startOnce sync.Once
+	startErr  error
+	buildOnce sync.Once
+	buildErr  error
+
+	timeout time.Duration
+	network string
+}
+
+func NewManager(opts ...ManagerOption) *Manager {
+	m := &Manager{
+		timeout: 30 * time.Minute,
+		network: "bridge",
+	}
+	for _, o := range opts {
+		o(m)
+	}
+	return m
+}
+
+func (m *Manager) Tools() []tool.BaseTool {
+	return []tool.BaseTool{
+		&WriteFileTool{mgr: m},
+		&EditFileTool{mgr: m},
+		&RunScriptTool{mgr: m},
+		&GetOutputTool{mgr: m},
+	}
+}
+
+func (m *Manager) ensureRunning(ctx context.Context) error {
+	m.startOnce.Do(func() {
+		if err := m.ensureImage(ctx); err != nil {
+			m.startErr = err
+			return
+		}
+
+		opts := defaultRunOpts()
+		opts.Network = m.network
+
+		containerID, err := dockerRun(ctx, imageName, opts)
+		if err != nil {
+			m.startErr = fmt.Errorf("failed to start sandbox: %w", err)
+			return
+		}
+
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		m.mu.Lock()
+		m.containerID = containerID
+		m.cancel = cancel
+		m.mu.Unlock()
+
+		go func() {
+			select {
+			case <-time.After(m.timeout):
+				m.Close()
+			case <-cancelCtx.Done():
+			}
+		}()
+
+		go func() {
+			select {
+			case <-ctx.Done():
+				m.Close()
+			case <-cancelCtx.Done():
+			}
+		}()
+	})
+	return m.startErr
+}
+
+func (m *Manager) ContainerID() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.containerID
+}
+
+func (m *Manager) Close() {
+	m.mu.Lock()
+	id := m.containerID
+	cancel := m.cancel
+	m.containerID = ""
+	m.cancel = nil
+	m.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if id != "" {
+		_ = dockerKill(context.Background(), id)
+	}
+}
+
+func (m *Manager) ensureImage(ctx context.Context) error {
+	m.buildOnce.Do(func() {
+		if dockerImageExists(ctx, imageName) {
+			return
+		}
+
+		tmpDir, err := writeBuildContext()
+		if err != nil {
+			m.buildErr = fmt.Errorf("prepare build context: %w", err)
+			return
+		}
+		defer os.RemoveAll(tmpDir)
+
+		m.buildErr = dockerBuild(ctx, tmpDir, imageName)
+	})
+	return m.buildErr
+}
+
+func writeBuildContext() (string, error) {
+	content, err := dockerfileFS.ReadFile("image/Dockerfile")
+	if err != nil {
+		return "", err
+	}
+
+	tmpDir, err := os.MkdirTemp("", "squeeze-sandbox-build-*")
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "Dockerfile"), content, 0644); err != nil {
+		os.RemoveAll(tmpDir)
+		return "", err
+	}
+
+	return tmpDir, nil
+}

--- a/internal/sandbox/run_script.go
+++ b/internal/sandbox/run_script.go
@@ -25,7 +25,11 @@ type RunScriptTool struct {
 func (t *RunScriptTool) Info() tool.ToolInfo {
 	return tool.NewToolInfo(
 		"docker_run_python",
-		"Execute a Python script inside the isolated Docker container. Pre-installed packages: requests, httpx, aiohttp, pwntools, impacket, cryptography, scapy, paramiko. Returns stdout, stderr, exit code.",
+		`Execute a Python script inside the Docker container and return stdout, stderr, exit code, and duration.
+The container has internet access and pre-installed packages: requests, httpx, aiohttp, pwntools, impacket, cryptography, pyjwt, scapy, paramiko, beautifulsoup4, lxml.
+Use this for batch HTTP probing, exploit scripts, data processing, and any multi-step automation that would be inefficient as individual tool calls.
+This runs Python in Docker — it cannot run Frida scripts, TypeScript, or JavaScript.
+For device instrumentation, use run_frida_script instead.`,
 		runScriptParams{},
 	)
 }

--- a/internal/sandbox/run_script.go
+++ b/internal/sandbox/run_script.go
@@ -1,0 +1,136 @@
+package sandbox
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/joakimcarlsson/ai/agent"
+	"github.com/joakimcarlsson/ai/tool"
+)
+
+type runScriptParams struct {
+	Path           string `json:"path"                      desc:"Path to the Python script inside the container"`
+	TimeoutSeconds int    `json:"timeout_seconds,omitempty" desc:"Execution timeout in seconds (default 30, max 300)"`
+	Args           string `json:"args,omitempty"            desc:"Command-line arguments to pass to the script"`
+}
+
+type RunScriptTool struct {
+	mgr *Manager
+}
+
+func (t *RunScriptTool) Info() tool.ToolInfo {
+	return tool.NewToolInfo(
+		"docker_run_python",
+		"Execute a Python script inside the isolated Docker container. Pre-installed packages: requests, httpx, aiohttp, pwntools, impacket, cryptography, scapy, paramiko. Returns stdout, stderr, exit code.",
+		runScriptParams{},
+	)
+}
+
+func (t *RunScriptTool) Run(ctx context.Context, params tool.ToolCall) (tool.ToolResponse, error) {
+	input, err := agent.ParseToolInput[runScriptParams](params.Input)
+	if err != nil {
+		return tool.NewTextErrorResponse(fmt.Sprintf("invalid input: %v", err)), nil
+	}
+
+	if input.Path == "" {
+		return tool.NewTextErrorResponse("path is required"), nil
+	}
+
+	timeout := 30
+	if input.TimeoutSeconds > 0 {
+		timeout = input.TimeoutSeconds
+	}
+	if timeout > 300 {
+		timeout = 300
+	}
+
+	if err := t.mgr.ensureRunning(ctx); err != nil {
+		return tool.NewTextErrorResponse(err.Error()), nil
+	}
+
+	containerID := t.mgr.ContainerID()
+
+	cmd := []string{"python", input.Path}
+	if input.Args != "" {
+		cmd = []string{"sh", "-c", fmt.Sprintf("python %s %s", input.Path, input.Args)}
+	}
+
+	start := time.Now()
+	stdout, stderr, exitCode, execErr := dockerExec(
+		ctx, containerID,
+		cmd,
+		time.Duration(timeout)*time.Second,
+	)
+	durationMs := time.Since(start).Milliseconds()
+
+	timedOut := false
+	if execErr != nil {
+		if strings.Contains(execErr.Error(), "timed out") {
+			timedOut = true
+		} else {
+			return tool.NewTextErrorResponse(fmt.Sprintf("execution failed: %v", execErr)), nil
+		}
+	}
+
+	type result struct {
+		Stdout     string `json:"stdout"`
+		Stderr     string `json:"stderr"`
+		ExitCode   int    `json:"exit_code"`
+		DurationMs int64  `json:"duration_ms"`
+		TimedOut   bool   `json:"timed_out"`
+		RunID      string `json:"run_id,omitempty"`
+	}
+
+	r := result{
+		Stdout:     stdout,
+		Stderr:     stderr,
+		ExitCode:   exitCode,
+		DurationMs: durationMs,
+		TimedOut:   timedOut,
+	}
+
+	if timedOut {
+		runID, bgErr := startBackground(ctx, containerID, input.Path, input.Args)
+		if bgErr == nil {
+			r.RunID = runID
+		}
+	}
+
+	return tool.NewJSONResponse(r), nil
+}
+
+func startBackground(ctx context.Context, containerID, path, args string) (string, error) {
+	runID, err := generateRunID()
+	if err != nil {
+		return "", err
+	}
+
+	scriptCmd := fmt.Sprintf("python %s", path)
+	if args != "" {
+		scriptCmd = fmt.Sprintf("python %s %s", path, args)
+	}
+
+	bgCmd := fmt.Sprintf(
+		"nohup sh -c '%s > /tmp/sq_%s.out 2> /tmp/sq_%s.err & echo $! > /tmp/sq_%s.pid'",
+		scriptCmd, runID, runID, runID,
+	)
+
+	_, _, _, err = dockerExec(ctx, containerID, []string{"sh", "-c", bgCmd}, 5*time.Second)
+	if err != nil {
+		return "", err
+	}
+
+	return runID, nil
+}
+
+func generateRunID() (string, error) {
+	b := make([]byte, 12)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/sandbox/write_file.go
+++ b/internal/sandbox/write_file.go
@@ -22,7 +22,11 @@ type WriteFileTool struct {
 func (t *WriteFileTool) Info() tool.ToolInfo {
 	return tool.NewToolInfo(
 		"docker_write_file",
-		"Create or overwrite a file inside the isolated Docker container. Use for Python scripts, wordlists, config files, or any data needed for security testing. NOT for Frida scripts or device files. Auto-lints .py files with py_compile.",
+		`Create or overwrite a file inside the Docker container.
+Use this to write Python scripts (.py), wordlists, config files, or any data that docker_run_python will consume.
+The Docker container is a completely separate environment from the target device — files written here cannot be accessed by Frida, the app, or any on-device tool.
+Do not use this for Frida scripts, TypeScript files, or anything intended to run on the target device.
+Automatically lints .py files with py_compile and reports syntax errors.`,
 		writeFileParams{},
 	)
 }

--- a/internal/sandbox/write_file.go
+++ b/internal/sandbox/write_file.go
@@ -1,0 +1,91 @@
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/joakimcarlsson/ai/agent"
+	"github.com/joakimcarlsson/ai/tool"
+)
+
+type writeFileParams struct {
+	Path    string `json:"path"    desc:"File path inside the container (e.g. /workspace/exploit.py)"`
+	Content string `json:"content" desc:"The full file content to write"`
+}
+
+type WriteFileTool struct {
+	mgr *Manager
+}
+
+func (t *WriteFileTool) Info() tool.ToolInfo {
+	return tool.NewToolInfo(
+		"docker_write_file",
+		"Create or overwrite a file inside the isolated Docker container. Use for Python scripts, wordlists, config files, or any data needed for security testing. NOT for Frida scripts or device files. Auto-lints .py files with py_compile.",
+		writeFileParams{},
+	)
+}
+
+func (t *WriteFileTool) Run(ctx context.Context, params tool.ToolCall) (tool.ToolResponse, error) {
+	input, err := agent.ParseToolInput[writeFileParams](params.Input)
+	if err != nil {
+		return tool.NewTextErrorResponse(fmt.Sprintf("invalid input: %v", err)), nil
+	}
+
+	if input.Path == "" {
+		return tool.NewTextErrorResponse("path is required"), nil
+	}
+
+	if err := t.mgr.ensureRunning(ctx); err != nil {
+		return tool.NewTextErrorResponse(err.Error()), nil
+	}
+
+	containerID := t.mgr.ContainerID()
+
+	_, stderr, exitCode, err := dockerExecWithStdin(
+		ctx, containerID,
+		[]string{"tee", input.Path},
+		input.Content,
+		30*time.Second,
+	)
+	if err != nil {
+		return tool.NewTextErrorResponse(fmt.Sprintf("failed to write file: %v", err)), nil
+	}
+	if exitCode != 0 {
+		return tool.NewTextErrorResponse(fmt.Sprintf("failed to write file: %s", stderr)), nil
+	}
+
+	lintPassed, lintOutput := lintPython(ctx, containerID, input.Path)
+
+	type result struct {
+		Path       string `json:"path"`
+		LintPassed bool   `json:"lint_passed"`
+		LintOutput string `json:"lint_output,omitempty"`
+	}
+
+	return tool.NewJSONResponse(result{
+		Path:       input.Path,
+		LintPassed: lintPassed,
+		LintOutput: lintOutput,
+	}), nil
+}
+
+func lintPython(ctx context.Context, containerID, path string) (bool, string) {
+	if !strings.HasSuffix(path, ".py") {
+		return true, ""
+	}
+
+	_, stderr, exitCode, err := dockerExec(
+		ctx, containerID,
+		[]string{"python", "-m", "py_compile", path},
+		10*time.Second,
+	)
+	if err != nil {
+		return false, fmt.Sprintf("lint failed: %v", err)
+	}
+	if exitCode != 0 {
+		return false, strings.TrimSpace(stderr)
+	}
+	return true, ""
+}

--- a/internal/tools/bash.go
+++ b/internal/tools/bash.go
@@ -26,7 +26,9 @@ func NewBash() *BashTool {
 func (t *BashTool) Info() tool.ToolInfo {
 	return tool.NewToolInfo(
 		"run_bash",
-		"Execute an arbitrary bash command and return stdout, stderr, and exit code.",
+		`Execute a bash command on the host machine and return stdout, stderr, and exit code.
+Use for running system tools like curl, nmap, sqlmap, or any CLI utility not covered by other tools.
+Commands run on the host, not inside the Docker container or on the target device.`,
 		BashParams{},
 	)
 }

--- a/internal/tools/cve_lookup.go
+++ b/internal/tools/cve_lookup.go
@@ -134,9 +134,9 @@ func NewCVELookupWithURL(baseURL string) *CVELookupTool {
 func (t *CVELookupTool) Info() tool.ToolInfo {
 	return tool.NewToolInfo(
 		"cve_lookup",
-		"Search the NIST National Vulnerability Database (NVD) for known CVEs affecting a product. "+
-			"Returns CVEs sorted by CVSS severity score (highest first) with descriptions, scores, and references. "+
-			"Use after tech_fingerprint or port_scan to check discovered technologies for known vulnerabilities.",
+		`Search the NIST National Vulnerability Database (NVD) for known CVEs affecting a product.
+Returns CVEs sorted by CVSS severity score (highest first) with descriptions, scores, and references.
+Use after tech_fingerprint or port_scan to check discovered technologies for known vulnerabilities.`,
 		CVELookupParams{},
 	)
 }

--- a/internal/tools/dns_lookup.go
+++ b/internal/tools/dns_lookup.go
@@ -39,13 +39,13 @@ func NewDNSLookup() *DNSLookupTool {
 func (t *DNSLookupTool) Info() tool.ToolInfo {
 	return tool.NewToolInfo(
 		"dns_lookup",
-		"Perform DNS lookups against a target host and return structured results. "+
-			"Supports record types: A, AAAA, MX, TXT, CNAME, NS, SOA, PTR, SRV, AXFR. "+
-			"Can enumerate subdomains using a built-in wordlist. "+
-			"Returns per-record type, TTL, value, and type-specific fields (priority, SOA serial/refresh/retry/expire, SRV port/weight). "+
-			"Use PTR with an IP address for reverse DNS lookups. "+
-			"Use AXFR to attempt a zone transfer. "+
-			"Defaults to A record lookup with 8.8.8.8:53 resolver.",
+		`Perform DNS lookups against a target host and return structured results.
+Supports record types: A, AAAA, MX, TXT, CNAME, NS, SOA, PTR, SRV, AXFR.
+Can enumerate subdomains using a built-in wordlist.
+Returns per-record type, TTL, value, and type-specific fields (priority, SOA serial/refresh/retry/expire, SRV port/weight).
+Use PTR with an IP address for reverse DNS lookups.
+Use AXFR to attempt a zone transfer.
+Defaults to A record lookup with 8.8.8.8:53 resolver.`,
 		DNSLookupParams{},
 	)
 }

--- a/internal/tools/fetch.go
+++ b/internal/tools/fetch.go
@@ -31,7 +31,10 @@ func NewFetch() *FetchTool {
 func (t *FetchTool) Info() tool.ToolInfo {
 	return tool.NewToolInfo(
 		"fetch_webpage",
-		"Fetch a URL and return the page content as Markdown. Use to read CVE pages, documentation, advisories, or any web page relevant to the engagement.",
+		`Fetch a URL and return the page content as cleaned Markdown.
+Use to read CVE detail pages, vendor advisories, documentation, or any web page relevant to the engagement.
+Strips navigation, ads, and boilerplate.
+For testing HTTP endpoints with full request/response control, use http_probe instead.`,
 		FetchParams{},
 	)
 }

--- a/internal/tools/http_probe.go
+++ b/internal/tools/http_probe.go
@@ -95,11 +95,11 @@ func NewHTTPProbe() *HTTPProbeTool {
 func (t *HTTPProbeTool) Info() tool.ToolInfo {
 	return tool.NewToolInfo(
 		"http_probe",
-		"Send an arbitrary HTTP request and return the full response including status code, headers, and body. "+
-			"Supports custom methods (GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD), request headers, and a raw body. "+
-			"Cookies are persisted across calls — use clearCookies to reset the jar. "+
-			"By default redirects are NOT followed; set followRedirects to true to chase them and receive the full redirect chain. "+
-			"Use for active endpoint probing, authentication flows, SSRF testing, or replaying modified captured requests.",
+		`Send an arbitrary HTTP request and return the full response including status code, headers, and body.
+Supports custom methods (GET, POST, PUT, DELETE, PATCH, OPTIONS, HEAD), request headers, and a raw body.
+Cookies are persisted across calls — use clearCookies to reset the jar.
+By default redirects are NOT followed; set followRedirects to true to chase them and receive the full redirect chain.
+Use for active endpoint probing, authentication flows, SSRF testing, or replaying modified captured requests.`,
 		HTTPProbeParams{},
 	)
 }

--- a/internal/tools/jwt_inspect.go
+++ b/internal/tools/jwt_inspect.go
@@ -26,7 +26,10 @@ func NewJWTInspect() *JWTInspectTool {
 func (t *JWTInspectTool) Info() tool.ToolInfo {
 	return tool.NewToolInfo(
 		"jwt_inspect",
-		"Decode a JWT without verification and return its header, payload, and expiry status. Optionally test for the alg:none vulnerability by producing a forged token with no signature.",
+		`Decode a JWT without verification and return its header, payload, and expiry status.
+Optionally test for the alg:none vulnerability by producing a forged token with no signature.
+Use this when you find JWTs in cookies, Authorization headers, or API responses.
+Does not verify signatures — use this for analysis, not validation.`,
 		JWTInspectParams{},
 	)
 }

--- a/internal/tools/port_scan.go
+++ b/internal/tools/port_scan.go
@@ -88,11 +88,11 @@ func NewPortScan() *PortScanTool {
 func (t *PortScanTool) Info() tool.ToolInfo {
 	return tool.NewToolInfo(
 		"port_scan",
-		"Run an nmap port scan against a target host and return structured results. "+
-			"Returns per-port state, service name, version, and CPE. "+
-			"Defaults to TCP connect scan (-sT). Enable service_scan for version detection (-sV). "+
-			"Supports custom port ranges, comma-separated ports, or topN (e.g. top100). "+
-			"Requires nmap installed on the host.",
+		`Run an nmap port scan against a target host and return structured results.
+Returns per-port state, service name, version, and CPE.
+Defaults to TCP connect scan (-sT). Enable service_scan for version detection (-sV).
+Supports custom port ranges, comma-separated ports, or topN (e.g. top100).
+Requires nmap installed on the host.`,
 		PortScanParams{},
 	)
 }

--- a/internal/tools/ssl_info.go
+++ b/internal/tools/ssl_info.go
@@ -50,13 +50,12 @@ func NewSSLInfo() *SSLInfoTool {
 func (t *SSLInfoTool) Info() tool.ToolInfo {
 	return tool.NewToolInfo(
 		"ssl_info",
-		"Connect to a host and retrieve TLS certificate and configuration details. "+
-			"Extracts the subject, SANs (Subject Alternative Names), issuer, validity dates, and serial number from the leaf certificate. "+
-			"SANs frequently expose additional subdomains and internal hostnames not visible in DNS enumeration, "+
-			"making this useful for attack surface mapping. "+
-			"Reports the negotiated TLS version (TLS 1.0/1.1 are findings) and cipher suite. "+
-			"Detects self-signed and expired certificates. "+
-			"Optionally probes whether the server accepts TLS 1.0 or TLS 1.1 connections.",
+		`Connect to a host and retrieve TLS certificate and configuration details.
+Extracts the subject, SANs (Subject Alternative Names), issuer, validity dates, and serial number from the leaf certificate.
+SANs frequently expose additional subdomains and internal hostnames not visible in DNS enumeration, making this useful for attack surface mapping.
+Reports the negotiated TLS version (TLS 1.0/1.1 are findings) and cipher suite.
+Detects self-signed and expired certificates.
+Optionally probes whether the server accepts TLS 1.0 or TLS 1.1 connections.`,
 		SSLInfoParams{},
 	)
 }

--- a/internal/tools/tech_fingerprint.go
+++ b/internal/tools/tech_fingerprint.go
@@ -40,9 +40,9 @@ func NewTechFingerprint() *TechFingerprintTool {
 func (t *TechFingerprintTool) Info() tool.ToolInfo {
 	return tool.NewToolInfo(
 		"tech_fingerprint",
-		"Fingerprint a URL to identify its technology stack: web server, CMS, frameworks, CDN, WAF, and JS libraries. "+
-			"Returns a list of detected technologies with versions and categories, plus a waf_detected flag. "+
-			"Run early in recon to understand what you're dealing with before active probing.",
+		`Fingerprint a URL to identify its technology stack: web server, CMS, frameworks, CDN, WAF, and JS libraries.
+Returns a list of detected technologies with versions and categories, plus a waf_detected flag.
+Run early in recon to understand what you're dealing with before active probing.`,
 		TechFingerprintParams{},
 	)
 }

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -60,7 +60,8 @@ func NewWebSearchWithEndpoints(_, searchURL string) *WebSearchTool {
 func (t *WebSearchTool) Info() tool.ToolInfo {
 	return tool.NewToolInfo(
 		"web_search",
-		"Search the web via DuckDuckGo and return ranked results with title, URL, and snippet. Use to look up CVEs, research targets, or find known vulnerability patterns.",
+		`Search the web via DuckDuckGo and return ranked results with title, URL, and snippet.
+Use to research targets, look up CVEs by product name, find known vulnerability patterns, locate public exploit code, or discover breach disclosures related to the target.`,
 		WebSearchParams{},
 	)
 }

--- a/internal/tools/whois.go
+++ b/internal/tools/whois.go
@@ -111,11 +111,11 @@ func NewWhoisWithURLs(bootstrapURL, arinURL string) *WhoisTool {
 func (t *WhoisTool) Info() tool.ToolInfo {
 	return tool.NewToolInfo(
 		"whois",
-		"Perform WHOIS/RDAP lookups for domains and IP addresses. "+
-			"For domains: returns registrar, org, registration/expiry dates, and name servers. "+
-			"For IPs: returns ASN, org, country, IP range (CIDR), and abuse contact. "+
-			"Uses RDAP (RESTful WHOIS) which returns structured JSON natively. "+
-			"Accepts any domain name (e.g. example.com) or IPv4/IPv6 address.",
+		`Perform WHOIS/RDAP lookups for domains and IP addresses.
+For domains: returns registrar, org, registration/expiry dates, and name servers.
+For IPs: returns ASN, org, country, IP range (CIDR), and abuse contact.
+Uses RDAP (RESTful WHOIS) which returns structured JSON natively.
+Accepts any domain name (e.g. example.com) or IPv4/IPv6 address.`,
 		WhoisParams{},
 	)
 }

--- a/squeeze.go
+++ b/squeeze.go
@@ -37,7 +37,6 @@ func NewAgent(llmClient llm.LLM, opts ...Option) *agent.Agent {
 	sbx := sandbox.NewManager()
 
 	allTools := Tools()
-	allTools = append(allTools, sbx.Tools()...)
 	allTools = append(allTools, cfg.extraTools...)
 
 	agentOpts := []agent.AgentOption{

--- a/squeeze.go
+++ b/squeeze.go
@@ -5,6 +5,7 @@ import (
 	llm "github.com/joakimcarlsson/ai/providers"
 	"github.com/joakimcarlsson/ai/tool"
 	"github.com/joakimcarlsson/squeeze/internal/prompt"
+	"github.com/joakimcarlsson/squeeze/internal/sandbox"
 	"github.com/joakimcarlsson/squeeze/internal/tools"
 )
 
@@ -33,13 +34,16 @@ func NewAgent(llmClient llm.LLM, opts ...Option) *agent.Agent {
 		o(cfg)
 	}
 
+	sbx := sandbox.NewManager()
+
 	allTools := Tools()
+	allTools = append(allTools, sbx.Tools()...)
 	allTools = append(allTools, cfg.extraTools...)
 
 	agentOpts := []agent.AgentOption{
 		agent.WithTools(allTools...),
 		agent.WithSystemPrompt(prompt.SystemPrompt),
-		agent.WithSubAgents(defaultSubAgents(llmClient)...),
+		agent.WithSubAgents(defaultSubAgents(llmClient, sbx)...),
 	}
 
 	agentOpts = append(agentOpts, cfg.agentOpts...)

--- a/test/tools/sandbox_test.go
+++ b/test/tools/sandbox_test.go
@@ -1,0 +1,649 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"testing"
+
+	"github.com/joakimcarlsson/squeeze/internal/sandbox"
+)
+
+func requireDocker(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not installed, skipping sandbox test")
+	}
+	cmd := exec.Command("docker", "info")
+	if err := cmd.Run(); err != nil {
+		t.Skip("docker daemon not reachable, skipping sandbox test")
+	}
+}
+
+func newTestManager(t *testing.T) *sandbox.Manager {
+	t.Helper()
+	mgr := sandbox.NewManager()
+	t.Cleanup(mgr.Close)
+	return mgr
+}
+
+// --- Info tests ---
+
+func TestSandboxTools_Info(t *testing.T) {
+	mgr := sandbox.NewManager()
+	tools := mgr.Tools()
+
+	expected := []string{
+		"docker_write_file",
+		"docker_edit_file",
+		"docker_run_python",
+		"docker_get_output",
+	}
+
+	if len(tools) != len(expected) {
+		t.Fatalf("expected %d tools, got %d", len(expected), len(tools))
+	}
+
+	for i, name := range expected {
+		info := tools[i].Info()
+		if info.Name != name {
+			t.Errorf("tool[%d]: expected name %q, got %q", i, name, info.Name)
+		}
+		if info.Description == "" {
+			t.Errorf("tool[%d] %q: expected non-empty description", i, name)
+		}
+	}
+}
+
+// --- Validation tests (no Docker needed) ---
+
+func TestSandboxWriteFile_EmptyPath(t *testing.T) {
+	mgr := sandbox.NewManager()
+	tools := mgr.Tools()
+	writeTool := tools[0]
+
+	resp, err := writeTool.Run(
+		context.Background(),
+		makeCall("docker_write_file", `{"path":"","content":"print('hi')"}`),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatal("expected error for empty path")
+	}
+}
+
+func TestSandboxEditFile_EmptyOldStr(t *testing.T) {
+	mgr := sandbox.NewManager()
+	tools := mgr.Tools()
+	editTool := tools[1]
+
+	resp, err := editTool.Run(
+		context.Background(),
+		makeCall("docker_edit_file", `{"path":"/workspace/test.py","old_str":"","new_str":"b"}`),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatal("expected error for empty old_str")
+	}
+}
+
+func TestSandboxRunScript_EmptyPath(t *testing.T) {
+	mgr := sandbox.NewManager()
+	tools := mgr.Tools()
+	runTool := tools[2]
+
+	resp, err := runTool.Run(
+		context.Background(),
+		makeCall("docker_run_python", `{"path":""}`),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatal("expected error for empty path")
+	}
+}
+
+func TestSandboxGetOutput_EmptyRunID(t *testing.T) {
+	mgr := sandbox.NewManager()
+	tools := mgr.Tools()
+	getTool := tools[3]
+
+	resp, err := getTool.Run(
+		context.Background(),
+		makeCall("docker_get_output", `{"run_id":""}`),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatal("expected error for empty run_id")
+	}
+}
+
+// --- Integration tests (require Docker) ---
+
+func TestSandbox_WriteAndRunScript(t *testing.T) {
+	requireDocker(t)
+
+	mgr := newTestManager(t)
+	tools := mgr.Tools()
+
+	// Write a Python script — this triggers lazy container start
+	writeTool := tools[0]
+	writeInput, _ := json.Marshal(map[string]string{
+		"path":    "/workspace/hello.py",
+		"content": "print('hello from sandbox')",
+	})
+	resp, err := writeTool.Run(context.Background(), makeCall("docker_write_file", string(writeInput)))
+	if err != nil {
+		t.Fatalf("write_file error: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("write_file tool error: %s", resp.Content)
+	}
+
+	var writeResult struct {
+		Path       string `json:"path"`
+		LintPassed bool   `json:"lint_passed"`
+	}
+	if err := json.Unmarshal([]byte(resp.Content), &writeResult); err != nil {
+		t.Fatalf("failed to parse write response: %v", err)
+	}
+	if !writeResult.LintPassed {
+		t.Error("expected lint to pass for valid Python")
+	}
+
+	// Run the script
+	runTool := tools[2]
+	runInput, _ := json.Marshal(map[string]string{
+		"path": "/workspace/hello.py",
+	})
+	resp, err = runTool.Run(context.Background(), makeCall("docker_run_python", string(runInput)))
+	if err != nil {
+		t.Fatalf("run_script error: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("run_script tool error: %s", resp.Content)
+	}
+
+	var runResult struct {
+		Stdout     string `json:"stdout"`
+		Stderr     string `json:"stderr"`
+		ExitCode   int    `json:"exit_code"`
+		DurationMs int64  `json:"duration_ms"`
+		TimedOut   bool   `json:"timed_out"`
+	}
+	if err := json.Unmarshal([]byte(resp.Content), &runResult); err != nil {
+		t.Fatalf("failed to parse run response: %v", err)
+	}
+	if runResult.Stdout != "hello from sandbox\n" {
+		t.Errorf("expected stdout 'hello from sandbox\\n', got %q", runResult.Stdout)
+	}
+	if runResult.ExitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", runResult.ExitCode)
+	}
+	if runResult.TimedOut {
+		t.Error("expected no timeout")
+	}
+	if runResult.DurationMs <= 0 {
+		t.Error("expected positive duration")
+	}
+}
+
+func TestSandbox_WriteLintError(t *testing.T) {
+	requireDocker(t)
+
+	mgr := newTestManager(t)
+	tools := mgr.Tools()
+
+	writeTool := tools[0]
+	writeInput, _ := json.Marshal(map[string]string{
+		"path":    "/workspace/bad.py",
+		"content": "def broken(\n",
+	})
+	resp, err := writeTool.Run(context.Background(), makeCall("docker_write_file", string(writeInput)))
+	if err != nil {
+		t.Fatalf("write_file error: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("write_file should not be a tool error even with lint failure: %s", resp.Content)
+	}
+
+	var result struct {
+		LintPassed bool   `json:"lint_passed"`
+		LintOutput string `json:"lint_output"`
+	}
+	if err := json.Unmarshal([]byte(resp.Content), &result); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if result.LintPassed {
+		t.Error("expected lint to fail for invalid Python syntax")
+	}
+	if result.LintOutput == "" {
+		t.Error("expected non-empty lint output")
+	}
+}
+
+func TestSandbox_EditFile(t *testing.T) {
+	requireDocker(t)
+
+	mgr := newTestManager(t)
+	tools := mgr.Tools()
+
+	// Write initial file
+	writeTool := tools[0]
+	writeInput, _ := json.Marshal(map[string]string{
+		"path":    "/workspace/edit_me.py",
+		"content": "msg = 'old value'\nprint(msg)",
+	})
+	resp, err := writeTool.Run(context.Background(), makeCall("docker_write_file", string(writeInput)))
+	if err != nil {
+		t.Fatalf("write_file error: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("write_file tool error: %s", resp.Content)
+	}
+
+	// Edit the file
+	editTool := tools[1]
+	editInput, _ := json.Marshal(map[string]string{
+		"path":    "/workspace/edit_me.py",
+		"old_str": "old value",
+		"new_str": "new value",
+	})
+	resp, err = editTool.Run(context.Background(), makeCall("docker_edit_file", string(editInput)))
+	if err != nil {
+		t.Fatalf("edit_file error: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("edit_file tool error: %s", resp.Content)
+	}
+
+	var editResult struct {
+		LintPassed bool `json:"lint_passed"`
+	}
+	if err := json.Unmarshal([]byte(resp.Content), &editResult); err != nil {
+		t.Fatalf("failed to parse edit response: %v", err)
+	}
+	if !editResult.LintPassed {
+		t.Error("expected lint to pass after edit")
+	}
+
+	// Run the edited file to verify
+	runTool := tools[2]
+	runInput, _ := json.Marshal(map[string]string{
+		"path": "/workspace/edit_me.py",
+	})
+	resp, err = runTool.Run(context.Background(), makeCall("docker_run_python", string(runInput)))
+	if err != nil {
+		t.Fatalf("run_script error: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("run_script tool error: %s", resp.Content)
+	}
+
+	var runResult struct {
+		Stdout string `json:"stdout"`
+	}
+	if err := json.Unmarshal([]byte(resp.Content), &runResult); err != nil {
+		t.Fatalf("failed to parse run response: %v", err)
+	}
+	if runResult.Stdout != "new value\n" {
+		t.Errorf("expected 'new value\\n', got %q", runResult.Stdout)
+	}
+}
+
+func TestSandbox_EditFileNotFound(t *testing.T) {
+	requireDocker(t)
+
+	mgr := newTestManager(t)
+	tools := mgr.Tools()
+
+	editTool := tools[1]
+	editInput, _ := json.Marshal(map[string]string{
+		"path":    "/workspace/does_not_exist.py",
+		"old_str": "a",
+		"new_str": "b",
+	})
+	resp, err := editTool.Run(context.Background(), makeCall("docker_edit_file", string(editInput)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatal("expected error when editing nonexistent file")
+	}
+}
+
+func TestSandbox_EditFileOldStrNotFound(t *testing.T) {
+	requireDocker(t)
+
+	mgr := newTestManager(t)
+	tools := mgr.Tools()
+
+	writeTool := tools[0]
+	writeInput, _ := json.Marshal(map[string]string{
+		"path":    "/workspace/test.py",
+		"content": "print('hello')",
+	})
+	writeTool.Run(context.Background(), makeCall("docker_write_file", string(writeInput)))
+
+	editTool := tools[1]
+	editInput, _ := json.Marshal(map[string]string{
+		"path":    "/workspace/test.py",
+		"old_str": "this does not exist",
+		"new_str": "replacement",
+	})
+	resp, err := editTool.Run(context.Background(), makeCall("docker_edit_file", string(editInput)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatal("expected error when old_str not found")
+	}
+}
+
+func TestSandbox_EditFileAmbiguousMatch(t *testing.T) {
+	requireDocker(t)
+
+	mgr := newTestManager(t)
+	tools := mgr.Tools()
+
+	writeTool := tools[0]
+	writeInput, _ := json.Marshal(map[string]string{
+		"path":    "/workspace/dup.py",
+		"content": "x = 1\nx = 1\n",
+	})
+	writeTool.Run(context.Background(), makeCall("docker_write_file", string(writeInput)))
+
+	editTool := tools[1]
+	editInput, _ := json.Marshal(map[string]string{
+		"path":    "/workspace/dup.py",
+		"old_str": "x = 1",
+		"new_str": "x = 2",
+	})
+	resp, err := editTool.Run(context.Background(), makeCall("docker_edit_file", string(editInput)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.IsError {
+		t.Fatal("expected error when old_str matches multiple times")
+	}
+}
+
+func TestSandbox_RunScriptStderr(t *testing.T) {
+	requireDocker(t)
+
+	mgr := newTestManager(t)
+	tools := mgr.Tools()
+
+	writeTool := tools[0]
+	writeInput, _ := json.Marshal(map[string]string{
+		"path":    "/workspace/stderr.py",
+		"content": "import sys\nsys.stderr.write('error output\\n')",
+	})
+	writeTool.Run(context.Background(), makeCall("docker_write_file", string(writeInput)))
+
+	runTool := tools[2]
+	runInput, _ := json.Marshal(map[string]string{
+		"path": "/workspace/stderr.py",
+	})
+	resp, err := runTool.Run(context.Background(), makeCall("docker_run_python", string(runInput)))
+	if err != nil {
+		t.Fatalf("run_script error: %v", err)
+	}
+
+	var result struct {
+		Stderr   string `json:"stderr"`
+		ExitCode int    `json:"exit_code"`
+	}
+	if err := json.Unmarshal([]byte(resp.Content), &result); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if result.Stderr != "error output\n" {
+		t.Errorf("expected stderr 'error output\\n', got %q", result.Stderr)
+	}
+}
+
+func TestSandbox_RunScriptNonZeroExit(t *testing.T) {
+	requireDocker(t)
+
+	mgr := newTestManager(t)
+	tools := mgr.Tools()
+
+	writeTool := tools[0]
+	writeInput, _ := json.Marshal(map[string]string{
+		"path":    "/workspace/fail.py",
+		"content": "import sys\nsys.exit(42)",
+	})
+	writeTool.Run(context.Background(), makeCall("docker_write_file", string(writeInput)))
+
+	runTool := tools[2]
+	runInput, _ := json.Marshal(map[string]string{
+		"path": "/workspace/fail.py",
+	})
+	resp, err := runTool.Run(context.Background(), makeCall("docker_run_python", string(runInput)))
+	if err != nil {
+		t.Fatalf("run_script error: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("non-zero exit should not be a tool error: %s", resp.Content)
+	}
+
+	var result struct {
+		ExitCode int `json:"exit_code"`
+	}
+	if err := json.Unmarshal([]byte(resp.Content), &result); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if result.ExitCode != 42 {
+		t.Errorf("expected exit code 42, got %d", result.ExitCode)
+	}
+}
+
+func TestSandbox_RunScriptTimeout(t *testing.T) {
+	requireDocker(t)
+
+	mgr := newTestManager(t)
+	tools := mgr.Tools()
+
+	writeTool := tools[0]
+	writeInput, _ := json.Marshal(map[string]string{
+		"path":    "/workspace/slow.py",
+		"content": "import time\ntime.sleep(60)",
+	})
+	writeTool.Run(context.Background(), makeCall("docker_write_file", string(writeInput)))
+
+	runTool := tools[2]
+	runInput, _ := json.Marshal(map[string]interface{}{
+		"path":            "/workspace/slow.py",
+		"timeout_seconds": 2,
+	})
+	resp, err := runTool.Run(context.Background(), makeCall("docker_run_python", string(runInput)))
+	if err != nil {
+		t.Fatalf("run_script error: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("timeout should not be a tool error: %s", resp.Content)
+	}
+
+	var result struct {
+		TimedOut bool   `json:"timed_out"`
+		RunID    string `json:"run_id"`
+	}
+	if err := json.Unmarshal([]byte(resp.Content), &result); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if !result.TimedOut {
+		t.Error("expected timed_out to be true")
+	}
+}
+
+func TestSandbox_NonPythonFileSkipsLint(t *testing.T) {
+	requireDocker(t)
+
+	mgr := newTestManager(t)
+	tools := mgr.Tools()
+
+	writeTool := tools[0]
+	writeInput, _ := json.Marshal(map[string]string{
+		"path":    "/workspace/data.txt",
+		"content": "this is not python {{{",
+	})
+	resp, err := writeTool.Run(context.Background(), makeCall("docker_write_file", string(writeInput)))
+	if err != nil {
+		t.Fatalf("write_file error: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("write_file tool error: %s", resp.Content)
+	}
+
+	var result struct {
+		LintPassed bool `json:"lint_passed"`
+	}
+	if err := json.Unmarshal([]byte(resp.Content), &result); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if !result.LintPassed {
+		t.Error("expected lint_passed=true for non-Python file (lint should be skipped)")
+	}
+}
+
+func TestSandbox_FullLifecycle(t *testing.T) {
+	requireDocker(t)
+
+	mgr := newTestManager(t)
+	tools := mgr.Tools()
+
+	// 1. Write a script
+	writeTool := tools[0]
+	writeInput, _ := json.Marshal(map[string]string{
+		"path":    "/workspace/scan.py",
+		"content": "results = []\nfor i in range(5):\n    results.append(f'endpoint_{i}: ok')\nprint('\\n'.join(results))",
+	})
+	resp, err := writeTool.Run(context.Background(), makeCall("docker_write_file", string(writeInput)))
+	if err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("write tool error: %s", resp.Content)
+	}
+
+	// 2. Run it
+	runTool := tools[2]
+	runInput, _ := json.Marshal(map[string]string{
+		"path": "/workspace/scan.py",
+	})
+	resp, err = runTool.Run(context.Background(), makeCall("docker_run_python", string(runInput)))
+	if err != nil {
+		t.Fatalf("run error: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("run tool error: %s", resp.Content)
+	}
+
+	var runResult struct {
+		Stdout   string `json:"stdout"`
+		ExitCode int    `json:"exit_code"`
+	}
+	if err := json.Unmarshal([]byte(resp.Content), &runResult); err != nil {
+		t.Fatalf("failed to parse run response: %v", err)
+	}
+	if runResult.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", runResult.ExitCode)
+	}
+
+	// 3. Edit it to add more endpoints
+	editTool := tools[1]
+	editInput, _ := json.Marshal(map[string]string{
+		"path":    "/workspace/scan.py",
+		"old_str": "for i in range(5):",
+		"new_str": "for i in range(10):",
+	})
+	resp, err = editTool.Run(context.Background(), makeCall("docker_edit_file", string(editInput)))
+	if err != nil {
+		t.Fatalf("edit error: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("edit tool error: %s", resp.Content)
+	}
+
+	// 4. Re-run
+	resp, err = runTool.Run(context.Background(), makeCall("docker_run_python", string(runInput)))
+	if err != nil {
+		t.Fatalf("re-run error: %v", err)
+	}
+
+	if err := json.Unmarshal([]byte(resp.Content), &runResult); err != nil {
+		t.Fatalf("failed to parse re-run response: %v", err)
+	}
+	if runResult.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d", runResult.ExitCode)
+	}
+
+	lines := 0
+	for _, c := range runResult.Stdout {
+		if c == '\n' {
+			lines++
+		}
+	}
+	if lines != 10 {
+		t.Errorf("expected 10 output lines after edit, got %d", lines)
+	}
+}
+
+func TestSandbox_NetworkAccess(t *testing.T) {
+	requireDocker(t)
+
+	mgr := newTestManager(t)
+	tools := mgr.Tools()
+
+	writeTool := tools[0]
+	writeInput, _ := json.Marshal(map[string]string{
+		"path": "/workspace/net_test.py",
+		"content": `import urllib.request
+try:
+    resp = urllib.request.urlopen("https://httpbin.org/get", timeout=10)
+    print(f"status:{resp.status}")
+except Exception as e:
+    print(f"error:{e}")
+`,
+	})
+	resp, err := writeTool.Run(context.Background(), makeCall("docker_write_file", string(writeInput)))
+	if err != nil {
+		t.Fatalf("write_file error: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("write_file tool error: %s", resp.Content)
+	}
+
+	runTool := tools[2]
+	runInput, _ := json.Marshal(map[string]string{
+		"path": "/workspace/net_test.py",
+	})
+	resp, err = runTool.Run(context.Background(), makeCall("docker_run_python", string(runInput)))
+	if err != nil {
+		t.Fatalf("run_script error: %v", err)
+	}
+	if resp.IsError {
+		t.Fatalf("run_script tool error: %s", resp.Content)
+	}
+
+	var result struct {
+		Stdout   string `json:"stdout"`
+		ExitCode int    `json:"exit_code"`
+	}
+	if err := json.Unmarshal([]byte(resp.Content), &result); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d (stderr may have details)", result.ExitCode)
+	}
+	if result.Stdout != "status:200\n" {
+		t.Errorf("expected 'status:200\\n', got %q", result.Stdout)
+	}
+}


### PR DESCRIPTION
closes #28 

This pull request introduces a Docker-based Python sandbox environment for scripting, analysis, and exploitation tasks, and integrates it as a toolset for sub-agents (`recon`, `web_analyst`, `exploit_runner`). It adds new agent tools for writing, editing, running, and retrieving output from Python scripts in the sandbox, and updates agent prompts and orchestration logic to clarify the separation between Docker and device environments.